### PR TITLE
Fix clippy lint warnings

### DIFF
--- a/libmtp-sys/src/lib.rs
+++ b/libmtp-sys/src/lib.rs
@@ -4,4 +4,3 @@
 
 pub mod bindings;
 pub use bindings::*;
-

--- a/src/device.rs
+++ b/src/device.rs
@@ -446,7 +446,7 @@ impl MtpDevice {
                 Err(self.latest_error().unwrap_or_default())
             } else {
                 let allowed_values =
-                    AllowedValues::from_raw(allowed_values_ptr).ok_or_else(|| Error::Unknown)?;
+                    AllowedValues::from_raw(allowed_values_ptr).ok_or(Error::Unknown)?;
                 ffi::LIBMTP_destroy_allowed_values_t(allowed_values_ptr);
                 Ok(allowed_values)
             }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -28,7 +28,7 @@ use crate::util::{CallbackReturn, HandlerReturn};
 use crate::Result;
 
 /// Internal function to retrieve files and folders from a single storage or the whole storage pool.
-fn files_and_folders<'a>(mtpdev: &'a MtpDevice, storage_id: u32, parent: Parent) -> Vec<File<'a>> {
+fn files_and_folders(mtpdev: &MtpDevice, storage_id: u32, parent: Parent) -> Vec<File> {
     let parent_id = parent.faf_id();
 
     let mut head =
@@ -132,13 +132,13 @@ impl<'a> Storage<'a> {
     /// Returns the storage type
     pub fn storage_type(&self) -> StorageType {
         let stype = unsafe { (*self.inner).StorageType };
-        StorageType::from_u16(stype).unwrap_or_else(|| StorageType::Undefined)
+        StorageType::from_u16(stype).unwrap_or(StorageType::Undefined)
     }
 
     /// Returns the file system type
     pub fn filesystem_type(&self) -> FilesystemType {
         let ftype = unsafe { (*self.inner).FilesystemType };
-        FilesystemType::from_u16(ftype).unwrap_or_else(|| FilesystemType::Undefined)
+        FilesystemType::from_u16(ftype).unwrap_or(FilesystemType::Undefined)
     }
 
     /// Returns the access capability

--- a/src/util.rs
+++ b/src/util.rs
@@ -93,7 +93,7 @@ pub(crate) unsafe extern "C" fn data_get_func_handler(
         &mut dyn FnMut(&mut [u8]) -> HandlerReturn,
     ) = std::mem::transmute(private);
 
-    let mut rsdata = vec![0 as u8; wantlen as usize];
+    let mut rsdata = vec![0u8; wantlen as usize];
 
     **handler_return = closure(&mut rsdata);
     let ret = match **handler_return {


### PR DESCRIPTION
As titled, clean up some lint warnings raised by running `cargo clippy`
